### PR TITLE
Target一覧ページ作成　#38

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,9 +24,16 @@ const routes: Routes = [
         canActivate: [AuthGuard],
       },
       {
-        path: 'target',
+        path: 'target/:targetId',
         loadChildren: () =>
           import('./target/target.module').then((m) => m.TargetModule),
+        canLoad: [AuthGuard],
+        canActivate: [AuthGuard],
+      },
+      {
+        path: 'index',
+        loadChildren: () =>
+          import('./index/index.module').then((m) => m.IndexModule),
         canLoad: [AuthGuard],
         canActivate: [AuthGuard],
       },

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -3,7 +3,8 @@
     <mat-sidenav #sidenav mode="push">
       <mat-nav-list>
         <a routerLink="/" mat-list-item>TOP</a>
-        <a routerLink="create" mat-list-item>新しい目標をつくる</a>
+        <a routerLink="/create" mat-list-item>新しい目標をつくる</a>
+        <a routerLink="/index" mat-list-item>目標一覧</a>
         <a mat-list-item>設定</a>
       </mat-nav-list>
       <mat-divider></mat-divider>

--- a/src/app/index/index-card/index-card.component.html
+++ b/src/app/index/index-card/index-card.component.html
@@ -1,0 +1,20 @@
+<div class="container">
+  <a routerLink="/target/{{ targetWithAuthor.targetId }}">
+    <mat-card class="index-card">
+      <mat-card-header>
+        <div mat-card-avatar class="index-card__avatar"></div>
+        <mat-card-title class="index-card__name">{{
+          targetWithAuthor.author.name
+        }}</mat-card-title>
+        <mat-card-subtitle class="index-card__date">{{
+          targetWithAuthor.createdAt.toDate() | date: 'yyyy/MM/dd'
+        }}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content class="index-card__target">
+        <p>
+          {{ targetWithAuthor.target }}
+        </p>
+      </mat-card-content>
+    </mat-card>
+  </a>
+</div>

--- a/src/app/index/index-card/index-card.component.scss
+++ b/src/app/index/index-card/index-card.component.scss
@@ -1,0 +1,11 @@
+.container {
+  padding: 16px;
+}
+
+.index-card {
+  background-color: rgb(248, 247, 246);
+  &__avatar {
+    border-radius: 50%;
+    background: black;
+  }
+}

--- a/src/app/index/index-card/index-card.component.spec.ts
+++ b/src/app/index/index-card/index-card.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndexCardComponent } from './index-card.component';
+
+describe('IndexCardComponent', () => {
+  let component: IndexCardComponent;
+  let fixture: ComponentFixture<IndexCardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [IndexCardComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IndexCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/index/index-card/index-card.component.ts
+++ b/src/app/index/index-card/index-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { TargetWithAuthor } from 'src/app/interfaces/target';
+
+@Component({
+  selector: 'app-index-card',
+  templateUrl: './index-card.component.html',
+  styleUrls: ['./index-card.component.scss'],
+})
+export class IndexCardComponent implements OnInit {
+  @Input() targetWithAuthor: TargetWithAuthor;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/index/index-routing.module.ts
+++ b/src/app/index/index-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { IndexComponent } from './index/index.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: IndexComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class IndexRoutingModule {}

--- a/src/app/index/index.module.ts
+++ b/src/app/index/index.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { IndexRoutingModule } from './index-routing.module';
+import { IndexComponent } from './index/index.component';
+import { IndexCardComponent } from './index-card/index-card.component';
+import { MatCardModule } from '@angular/material/card';
+
+@NgModule({
+  declarations: [IndexComponent, IndexCardComponent],
+  imports: [CommonModule, IndexRoutingModule, MatCardModule],
+})
+export class IndexModule {}

--- a/src/app/index/index/index.component.html
+++ b/src/app/index/index/index.component.html
@@ -1,0 +1,9 @@
+<div class="containar">
+  <app-index-card
+    [targetWithAuthor]="targetWithAuthor"
+    *ngFor="let targetWithAuthor of targetWithAuthor$ | async"
+  ></app-index-card>
+  <div class="index">
+    <div class="index__info"></div>
+  </div>
+</div>

--- a/src/app/index/index/index.component.spec.ts
+++ b/src/app/index/index/index.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndexComponent } from './index.component';
+
+describe('IndexComponent', () => {
+  let component: IndexComponent;
+  let fixture: ComponentFixture<IndexComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [IndexComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IndexComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/index/index/index.component.ts
+++ b/src/app/index/index/index.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { TargetService } from 'src/app/services/target.service';
+import { TargetWithAuthor } from 'src/app/interfaces/target';
+
+@Component({
+  selector: 'app-index',
+  templateUrl: './index.component.html',
+  styleUrls: ['./index.component.scss'],
+})
+export class IndexComponent implements OnInit {
+  targetWithAuthor$: Observable<
+    TargetWithAuthor[]
+  > = this.targetService.getTargetWithAuthor();
+
+  constructor(private targetService: TargetService) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/interfaces/target.ts
+++ b/src/app/interfaces/target.ts
@@ -1,4 +1,5 @@
 import { firestore } from 'firebase';
+import { User } from './user';
 
 export interface Target {
   authorUid: string;
@@ -6,4 +7,8 @@ export interface Target {
   target: string;
   targetDate: firestore.Timestamp;
   createdAt: firestore.Timestamp;
+}
+
+export interface TargetWithAuthor extends Target {
+  author: User;
 }

--- a/src/app/interfaces/task.ts
+++ b/src/app/interfaces/task.ts
@@ -1,0 +1,7 @@
+import { firestore } from 'firebase';
+
+export interface Task {
+  task: string;
+  createdAt: firestore.Timestamp;
+  taskId: string;
+}

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,7 +1,9 @@
+import { firestore } from 'firebase';
+
 export interface User {
   authorUid: string;
   avatarURL: string;
   name: string;
-  createdAt: Date;
+  createdAt: firestore.Timestamp;
   email: string;
 }

--- a/src/app/services/target.service.ts
+++ b/src/app/services/target.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
-import { Target } from '../interfaces/target';
+import { Target, TargetWithAuthor } from '../interfaces/target';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, combineLatest, of, from } from 'rxjs';
 import { AuthService } from './auth.service';
-import { map } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { firestore } from 'firebase';
-
+import { User } from '../interfaces/user';
 @Injectable({
   providedIn: 'root',
 })
@@ -19,28 +19,34 @@ export class TargetService {
     private router: Router
   ) {}
 
-  getTargetByAuthorId(authorUid: string): Observable<Target> {
-    return this.db
-      .collection<Target>('targets', (ref) =>
-        ref.where('authorUid', '==', authorUid)
-      )
-      .valueChanges()
-      .pipe(
-        map((targets) => {
-          if (targets.length) {
-            return targets[0];
-          } else {
-            return null;
-          }
-        })
-      );
-  }
+  // マイページで一覧として表示する
+  // getTargetByAuthorId(authorUid: string): Observable<Target[]> {
+  //   return this.db
+  //     .collection<Target>('targetWithAuthor', (ref) =>
+  //       ref.where('authorUid', '==', 'authorUid')
+  //     ).valueChanges();
 
-  updateTarget(targeId: string, data: Target): Promise<void> {
+  ////    return this.db
+  ////      .collection<Target>('targets', (ref) =>
+  ////    ////    ref.where('authorUid', '==', authorUid)
+  ////      )
+  ////      .valueChanges()
+  ////      .pipe(
+  ////    ////    map((targets) => {
+  ////    ////      if (targets.length) {
+  ////    ////    ////    return targets[0];
+  ////    ////      } else {
+  ////    ////    ////    return null;
+  ////    ////      }
+  ////    ////    })
+  ////      );
+  // }
+
+  updateTarget(targetId: string, data: Target): Promise<void> {
     return this.db.doc('targets/${targetId}').update(data);
   }
 
-  deleteTarget(targeId: string): Promise<void> {
+  deleteTarget(targetId: string): Promise<void> {
     return this.db.doc('targets/${targetId}').delete();
   }
 
@@ -64,7 +70,67 @@ export class TargetService {
       });
   }
 
-  getTargetByTargetId(targeId: string): Observable<Target> {
-    return this.db.doc<Target>(`targets/${targeId}`).valueChanges();
+  getTargetWithAuthor(): Observable<TargetWithAuthor[]> {
+    let targets: Target[];
+    return this.db
+      .collection<Target>('targets', (ref) => {
+        return ref.orderBy('createdAt', 'desc');
+      })
+      .valueChanges()
+      .pipe(
+        switchMap((posts: Target[]) => {
+          targets = posts;
+
+          if (targets.length) {
+            const uniqueAuthorIds: string[] = targets
+              .filter((target, index, array) => {
+                return (
+                  array.findIndex(
+                    (value) => value.authorUid === target.authorUid
+                  ) === index
+                );
+              })
+              .map((target) => target.authorUid);
+            return combineLatest(
+              uniqueAuthorIds.map((id) => {
+                return this.db.doc(`users/${id}`).valueChanges();
+              })
+            ); // 重複削除　配列　set
+          } else {
+            return of([]);
+          }
+        }),
+        map((users: User[]) => {
+          return targets.map((target) => {
+            const result: TargetWithAuthor = {
+              ...target,
+              author: users.find((user) => user.authorUid === target.authorUid),
+            };
+            return result;
+          });
+        })
+      );
+  }
+
+  getTargetsWithAuthorsByTargetId(
+    targetId: string
+  ): Observable<TargetWithAuthor> {
+    return this.db
+      .doc<Target>(`targets/${targetId}`)
+      .valueChanges()
+      .pipe(
+        switchMap((target: Target) => {
+          const user$: Observable<User> = this.db
+            .doc<User>(`users/${target.authorUid}`)
+            .valueChanges();
+          return combineLatest([user$, of(target)]);
+        }),
+        map(([author, target]) => {
+          return {
+            ...target,
+            author,
+          };
+        })
+      );
   }
 }

--- a/src/app/services/target.service.ts
+++ b/src/app/services/target.service.ts
@@ -19,7 +19,6 @@ export class TargetService {
     private router: Router
   ) {}
 
-  // マイページで一覧として表示する
   // getTargetByAuthorId(authorUid: string): Observable<Target[]> {
   //   return this.db
   //     .collection<Target>('targetWithAuthor', (ref) =>

--- a/src/app/services/task.service.spec.ts
+++ b/src/app/services/task.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TaskService } from './task.service';
+
+describe('TaskService', () => {
+  let service: TaskService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TaskService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { createUploadTask } from '@angular/fire/storage/task';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+import { map } from 'rxjs/operators';
+import { firestore } from 'firebase';
+import { Task } from '../interfaces/task';
+import { promise } from 'protractor';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TaskService {
+  constructor(private db: AngularFirestore) {}
+
+  createTask(data: Task): Promise<void> {
+    const taskId = this.db.createId();
+    return this.db.doc(`tasks/${taskId}`).set({
+      taskId,
+      ...data,
+      createdAt: new Date(),
+    });
+  }
+
+  deleteTask(taskId: string): Promise<void> {
+    return this.db.doc(`tasks/${taskId}`).delete();
+  }
+
+  getTaskByTaskId(taskId: string): Observable<Task> {
+    return this.db.doc<Task>(`tasks/${taskId}`).valueChanges();
+  }
+}

--- a/src/app/target/target-routing.module.ts
+++ b/src/app/target/target-routing.module.ts
@@ -8,10 +8,6 @@ const routes: Routes = [
     pathMatch: 'full',
     component: TargetComponent,
   },
-  {
-    path: ':targetId',
-    component: TargetComponent,
-  },
 ];
 
 @NgModule({

--- a/src/app/target/target.module.ts
+++ b/src/app/target/target.module.ts
@@ -4,12 +4,12 @@ import { CommonModule } from '@angular/common';
 import { TargetRoutingModule } from './target-routing.module';
 import { TargetComponent } from './target/target.component';
 
-import {MatExpansionModule} from '@angular/material/expansion';
-import {DragDropModule} from '@angular/cdk/drag-drop';
-import {MatCardModule} from '@angular/material/card';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { MatCardModule } from '@angular/material/card';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import {MatProgressBarModule} from '@angular/material/progress-bar';
-
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [TargetComponent],
@@ -22,6 +22,7 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
     FormsModule,
     ReactiveFormsModule,
     MatProgressBarModule,
-  ]
+    MatButtonModule,
+  ],
 })
-export class TargetModule { }
+export class TargetModule {}

--- a/src/app/target/target/target.component.html
+++ b/src/app/target/target/target.component.html
@@ -1,19 +1,29 @@
-<div class="container">
-  <div class="target-container" *ngIf="target$ | async as target">
-    <div class="target">
-      <mat-card class="target__header">
-        <p class="target__text">目標: {{ target.target }}</p>
-        <div class="target__body">
-          <p class="target__authorId">{{ target.authorUid }} さん</p>
-          <p class="target__createdAt">
-            {{ target.createdAt.toDate() | date: 'yyyy/MM/dd' }} からです。
-          </p>
-          <p class="target__date">
-            {{ target.targetDate.toDate() | date: 'yyyy/MM/dd' }} までです。
-          </p>
-        </div>
-      </mat-card>
-      <div class="target__task"></div>
-    </div>
-  </div>
+<div class="container" *ngIf="target$ | async as target">
+  <mat-card class="target-card">
+    <mat-card-header class="target-card__header">
+      <div mat-card-avatar class="target-card__avatar"></div>
+      <mat-card-title>{{ target.author.name }} さん</mat-card-title>
+      <mat-card-subtitle class="target-card__date">
+        {{
+          target.createdAt.toDate() | date: 'yyyy/MM/dd'
+        }}から</mat-card-subtitle
+      >
+      <mat-card-subtitle>
+        {{ target.targetDate.toDate() | date: 'yyyy/MM/dd' }} まで
+      </mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <p class="target-card__main">
+        {{ target.target }}
+      </p>
+    </mat-card-content>
+
+    <button mat-stroked-button color="warn" class="new-task">
+      今日やることを追加しよう！
+    </button>
+    <button mat-stroked-button>
+      <a class="index" routerLink="/index">目標一覧へ</a>
+    </button>
+  </mat-card>
 </div>

--- a/src/app/target/target/target.component.html
+++ b/src/app/target/target/target.component.html
@@ -22,8 +22,8 @@
     <button mat-stroked-button color="warn" class="new-task">
       今日やることを追加しよう！
     </button>
-    <button mat-stroked-button>
-      <a class="index" routerLink="/index">目標一覧へ</a>
-    </button>
+    <a routerLink="/index" class="index" button mat-stroked-button
+      >一覧に戻る</a
+    >
   </mat-card>
 </div>

--- a/src/app/target/target/target.component.scss
+++ b/src/app/target/target/target.component.scss
@@ -1,0 +1,26 @@
+.container {
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: 0 0 3px #ccc;
+}
+
+.target-card {
+  padding: 16px;
+  &__header {
+    display: flex;
+  }
+  &__avatar {
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    background: black;
+    margin-right: 8px;
+  }
+}
+
+.index {
+  text-decoration: none;
+}
+a:visited {
+  color: black;
+}

--- a/src/app/target/target/target.component.ts
+++ b/src/app/target/target/target.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
-import { Target } from 'src/app/interfaces/target';
+import { Component, OnInit, Input } from '@angular/core';
+import { Target, TargetWithAuthor } from 'src/app/interfaces/target';
 import { TargetService } from 'src/app/services/target.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { Observable } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { switchMap, map } from 'rxjs/operators';
+import { TaskService } from 'src/app/services/task.service';
 
 @Component({
   selector: 'app-target',
@@ -12,25 +13,19 @@ import { switchMap, map } from 'rxjs/operators';
   styleUrls: ['./target.component.scss'],
 })
 export class TargetComponent implements OnInit {
-  target$: Observable<Target> = this.route.paramMap.pipe(
-    // tslint:disable-next-line: no-shadowed-variable
-    switchMap((map) => {
-      const id = map.get('targetId');
-      return this.targetService.getTargetByTargetId(id);
+  target$: Observable<TargetWithAuthor> = this.route.paramMap.pipe(
+    switchMap((paramMap) => {
+      const id = paramMap.get('targetId');
+      return this.targetService.getTargetsWithAuthorsByTargetId(id);
     })
   );
 
   constructor(
     private targetService: TargetService,
+    private taskService: TaskService,
     private authService: AuthService,
     private route: ActivatedRoute
-  ) {
-    route.paramMap.subscribe((params) => {
-      this.target$ = this.targetService.getTargetByTargetId(
-        params.get('targetId')
-      );
-    });
-  }
+  ) {}
 
   ngOnInit(): void {}
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,7 @@
 html,
 body {
   height: 100%;
+  background: red($color: #ffdcdc);
 }
 body {
   margin: 0;
@@ -10,4 +11,8 @@ body {
 }
 img {
   max-width: 100%;
+}
+
+a {
+  text-decoration: none;
 }


### PR DESCRIPTION
feat #38 

以下のように実装いたしました。ご確認宜しくお願い致します。

## 実装内容
- Target/User interfaceにcombineLatestを行い、getTargetsWithAuthorsByTargetId関数を作成し、
ユーザー情報とTargetを取得できるようにした(target.service.ts)。
- 上記関数を用いたTargetページを作成。
- Target一覧を取得するgetTargetWithAuthor関数を用いて、一覧ページを作成。
- 上記関数を作成日(降順)にソートするように変更。
- Header/Target/Indexの動線を作成

## 実装イメージ
![image](https://user-images.githubusercontent.com/63516648/87380271-1d5fb300-c5cd-11ea-8894-9875393b1c2d.png)

![image](https://user-images.githubusercontent.com/63516648/87380387-58fa7d00-c5cd-11ea-852a-ac07a6eadfc1.png)

